### PR TITLE
Set accum_t to better default and use for global pooling

### DIFF
--- a/hls4ml/model/hls_layers.py
+++ b/hls4ml/model/hls_layers.py
@@ -360,9 +360,24 @@ class Layer(object):
         self.weights = OrderedDict()
         self.variables = OrderedDict()
         self.precision = OrderedDict()
-        accum_t = HLSType(*reversed(self.model.config.get_precision(self, 'accum')))
+
+        # We set 'accum' precision to match input tensor's precision if 'accum' was not explicitly set
+        def_type_obj, _ = self.model.config.get_precision(self, 'default')
+        acc_type_obj, acc_type_name = self.model.config.get_precision(self, 'accum')
+
+        inp = self.get_input_variable()
+        if inp is not None:
+            inp_type_obj = inp.type.precision
+        else:
+            inp_type_obj = def_type_obj
+
+        if acc_type_obj == def_type_obj: # 'accum' precision not defined in config
+            acc_type_obj = inp_type_obj # use input tensor's precision for 'accum'
+
+        accum_t = HLSType(acc_type_name, acc_type_obj) 
         self.precision[accum_t.name] = accum_t
         self.set_attr('accum_t', accum_t.precision)
+
         self.reuse_factor = self.model.config.get_reuse_factor(self)
 
         layer_config = self.model.config.get_layer_config(self)

--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -439,7 +439,7 @@ class HLSModel(object):
         return variables
 
     def get_layer_output_variable(self, output_name):
-        return self.output_vars[output_name]
+        return self.output_vars.get(output_name, None)
 
     def write(self):
         def make_stamp():

--- a/hls4ml/templates/vivado/nnet_utils/nnet_pooling_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_pooling_stream.h
@@ -19,15 +19,9 @@ T reduce_pool(T x[N]) {
         Op_max<T> op_max;
         return reduce<T, N, Op_max<T>>(x, op_max);
     } else {
-        Op_add<typename CONFIG_T::accum_t> op_add;
-        typename CONFIG_T::accum_t x_wide[N];
-	for (int i = 0; i < N; i++){
-            #pragma HLS UNROLL
-	    x_wide[i] = x[i];
-	}
-        typename CONFIG_T::accum_t sum = reduce<typename CONFIG_T::accum_t, N, Op_add<typename CONFIG_T::accum_t>>(x_wide, op_add);
-        T avg = sum/N;
-        return avg;
+        Op_add<T> op_add;
+        T sum = reduce<T, N, Op_add<T>>(x, op_add);
+        return sum / N;
     }
 }
 
@@ -81,7 +75,7 @@ void compute_pool_2d(
         #pragma HLS ARRAY_PARTITION variable=pool_table_width complete
     }
 
-    typename data_T::value_type pool_window[CONFIG_T::pool_height * CONFIG_T::pool_width];
+    typename CONFIG_T::accum_t pool_window[CONFIG_T::pool_height * CONFIG_T::pool_width];
     #pragma HLS ARRAY_PARTITION variable=pool_window complete
 
     const unsigned sh_idx = pool_table_height[h_idx] * CONFIG_T::pool_width;
@@ -105,9 +99,9 @@ void compute_pool_2d(
                     pool_window[f] = data_window[c * CONFIG_T::pool_height * CONFIG_T::pool_width + f].read();
                 }
                 if (res_T::size / CONFIG_T::n_filt == 1) { // Saves resources if we don't pack output, compiler will remove the else branch
-                    res_pack[c] = reduce_pool<typename data_T::value_type, CONFIG_T::pool_height * CONFIG_T::pool_width, CONFIG_T>(pool_window);
+                    res_pack[c] = reduce_pool<typename CONFIG_T::accum_t, CONFIG_T::pool_height * CONFIG_T::pool_width, CONFIG_T>(pool_window);
                 } else {
-                    res_pack[outputs_ready * CONFIG_T::n_filt + c] = reduce_pool<typename data_T::value_type, CONFIG_T::pool_height * CONFIG_T::pool_width, CONFIG_T>(pool_window);
+                    res_pack[outputs_ready * CONFIG_T::n_filt + c] = reduce_pool<typename CONFIG_T::accum_t, CONFIG_T::pool_height * CONFIG_T::pool_width, CONFIG_T>(pool_window);
                 }
 
             }
@@ -189,7 +183,7 @@ void compute_pool_1d(
         #pragma HLS ARRAY_PARTITION variable=pool_table_width complete
     }
 
-    typename data_T::value_type pool_window[CONFIG_T::pool_width];
+    typename CONFIG_T::accum_t pool_window[CONFIG_T::pool_width];
     #pragma HLS ARRAY_PARTITION variable=pool_window complete
 
     const unsigned wp_idx = w_idx * (data_T::size / CONFIG_T::n_filt);
@@ -212,9 +206,9 @@ void compute_pool_1d(
                     pool_window[f] = data_window[c * CONFIG_T::pool_width + f].read();
                 }
                 if (res_T::size / CONFIG_T::n_filt == 1) { // Saves resources if we don't pack output, compiler will remove the else branch
-                    res_pack[c] = reduce_pool<typename data_T::value_type, CONFIG_T::pool_width, CONFIG_T>(pool_window);
+                    res_pack[c] = reduce_pool<typename CONFIG_T::accum_t, CONFIG_T::pool_width, CONFIG_T>(pool_window);
                 } else {
-                    res_pack[outputs_ready * CONFIG_T::n_filt + c] = reduce_pool<typename data_T::value_type, CONFIG_T::pool_width, CONFIG_T>(pool_window);
+                    res_pack[outputs_ready * CONFIG_T::n_filt + c] = reduce_pool<typename CONFIG_T::accum_t, CONFIG_T::pool_width, CONFIG_T>(pool_window);
                 }
 
             }
@@ -285,19 +279,19 @@ void compute_global_pool(
     const unsigned h_idx,
     const unsigned w_idx,
     const data_T& in_elem,
-    typename data_T::value_type data_window[CONFIG_T::n_filt]
+    typename CONFIG_T::accum_t data_window[CONFIG_T::n_filt]
 ) {
     PoolFilt: for (unsigned c = 0; c < CONFIG_T::n_filt; c++) {
         #pragma HLS UNROLL
 
-        typename data_T::value_type data_pack[data_T::size / CONFIG_T::n_filt];
+        typename CONFIG_T::accum_t data_pack[data_T::size / CONFIG_T::n_filt];
         #pragma HLS ARRAY_PARTITION variable=data_pack complete dim=0
 
         PixelLoop: for (unsigned p = 0; p < data_T::size / CONFIG_T::n_filt; p++) {
             #pragma HLS UNROLL
             data_pack[p] = in_elem[p * CONFIG_T::n_filt + c];
         }
-        data_window[c] = reduce_global_pool<typename data_T::value_type, data_T::size / CONFIG_T::n_filt, CONFIG_T>(data_window[c], data_pack);
+        data_window[c] = reduce_global_pool<typename CONFIG_T::accum_t, data_T::size / CONFIG_T::n_filt, CONFIG_T>(data_window[c], data_pack);
     }
 }
 
@@ -309,12 +303,12 @@ void global_pooling2d_cl(
     assert(CONFIG_T::pad_top == 0 && CONFIG_T::pad_bottom == 0 && CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0);
     assert(CONFIG_T::pool_height == CONFIG_T::stride_height && CONFIG_T::pool_width == CONFIG_T::stride_width);
 
-    typename data_T::value_type data_window[CONFIG_T::n_filt];
+    typename CONFIG_T::accum_t data_window[CONFIG_T::n_filt];
     #pragma HLS ARRAY_PARTITION variable=data_window complete
 
-    typename data_T::value_type init = 0;
+    typename CONFIG_T::accum_t init = 0;
     if (CONFIG_T::pool_op == Max) {
-        init = hls::numeric_limits<typename data_T::value_type>::min();
+        init = hls::numeric_limits<typename CONFIG_T::accum_t>::min();
     }
 
     PoolInitLoop: for (unsigned i_init = 0; i_init < CONFIG_T::n_filt; i_init++) {

--- a/hls4ml/templates/vivado_template.py
+++ b/hls4ml/templates/vivado_template.py
@@ -163,6 +163,7 @@ global_pooling1d_config_template = """struct config{index} : nnet::pooling1d_con
     static const unsigned pad_right = {pad_right};
     static const unsigned stride = {stride};
     static const nnet::Pool_Op pool_op = nnet::{pool_op};
+    typedef {accum_t} accum_t;
 }};\n"""
 
 global_pooling2d_config_template = """struct config{index} : nnet::pooling2d_config {{
@@ -171,6 +172,7 @@ global_pooling2d_config_template = """struct config{index} : nnet::pooling2d_con
     static const unsigned n_filt = {n_filt};
     static const nnet::Pool_Op pool_op = nnet::{pool_op};
     static const unsigned reuse = {reuse};
+    typedef {accum_t} accum_t;
 }};\n"""
 
 zeropad1d_config_template = """struct config{index} : nnet::padding1d_config {{


### PR DESCRIPTION
This adds the proper default for `accum_t` if not explicitly set and also uses accum_t for global pooling. I changed the flow to use `accum_t` to `pool_window` and reduce on that, that feels more intuitive than using extra array for repacking to `accum_t` in case of average pooling.