### PR TITLE
Fixes for Permute layer

### DIFF
--- a/hls4ml/converters/keras/core.py
+++ b/hls4ml/converters/keras/core.py
@@ -120,19 +120,3 @@ def parse_batchnorm_layer(keras_layer, input_names, input_shapes, data_reader, c
         layer['n_filt']=input_shapes[0][3]
 
     return layer, [shape for shape in input_shapes[0]]
-
-@keras_handler('Permute')
-def parse_permute_layer(keras_layer, input_names, input_shapes, data_reader, config):
-    assert(keras_layer['class_name'] == 'Permute')
-
-    layer = parse_default_keras_layer(keras_layer, input_names)
-
-    layer['class_name'] = 'Transpose'
-    swap = keras_layer['config']['dims']
-    perm = list(range(len(input_shapes[0])))
-    perm[swap[0]], perm[swap[1]] = perm[swap[1]], perm[swap[0]]
-    layer['perm'] = perm
-    
-    output_shape = [input_shapes[0][p] for p in perm]
-
-    return layer, output_shape

--- a/hls4ml/converters/keras/reshape.py
+++ b/hls4ml/converters/keras/reshape.py
@@ -42,3 +42,17 @@ def parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader, conf
         output_shape = [input_shapes[0][0], layer['out_height'], layer['out_width'], layer['n_chan']]
 
     return layer, output_shape
+
+@keras_handler('Permute')
+def parse_permute_layer(keras_layer, input_names, input_shapes, data_reader, config):
+    assert(keras_layer['class_name'] == 'Permute')
+
+    layer = parse_default_keras_layer(keras_layer, input_names)
+
+    layer['class_name'] = 'Transpose'
+    dims = keras_layer['config']['dims']
+    layer['perm'] = [dim - 1 for dim in keras_layer['config']['dims']]
+    
+    output_shape = [input_shapes[0][0]] + [input_shapes[0][s] for s in dims]
+
+    return layer, output_shape

--- a/hls4ml/model/hls_layers.py
+++ b/hls4ml/model/hls_layers.py
@@ -1511,29 +1511,27 @@ class Transpose(Layer):
         inp = self.get_input_variable(self.inputs[0])
         perm = self.get_attr('perm')
         self.set_attr('dim', '{}d'.format(len(inp.shape)))
-        if len(perm) == 4 and perm[0] == 0:
-            perm = [i - 1 for i in perm[1:]]
-        elif len(perm) == 3 and len(inp.shape) == 2 and perm[0] == 0:
-            perm = [i - 1 for i in perm[1:]]
+        if len(perm) > 3:
+            raise Exception('ERROR: Transpose of tensors with rank > 3 is not yet supported.')
         shape = [inp.shape[i] for i in perm]
         if len(shape) == 2:
             self.set_attr('perm_str', ','.join(['0'] + [str(i+1) for i in perm]))
             dims = ['OUT_HEIGHT_{}'.format(self.index), 'OUT_WIDTH_{}'.format(self.index)]
             self.set_attr('depth', 1)
-            self.set_attr('height', shape[0])
-            self.set_attr('width', shape[1])
+            self.set_attr('height', inp.shape[0])
+            self.set_attr('width', inp.shape[1])
         else:
             shape = [inp.shape[i] for i in perm]
             self.set_attr('perm_str', ','.join([str(i) for i in perm]))
             dims = ['OUT_DEPTH_{}'.format(self.index), 'OUT_HEIGHT_{}'.format(self.index), 'OUT_WIDTH_{}'.format(self.index)]
-            self.set_attr('depth', shape[0])
-            self.set_attr('height', shape[1])
-            self.set_attr('width', shape[2])
+            self.set_attr('depth', inp.shape[0])
+            self.set_attr('height', inp.shape[1])
+            self.set_attr('width', inp.shape[2])
         self.add_output_variable(shape, dims)
 
     def function_cpp(self):
         params = self._default_function_params()
-        params['dim'] = '3d' # always use 3d instead of self.get_attr('dim')
+        params['dim'] = self.get_attr('dim')
 
         return [self._function_template.format(**params)]
 
@@ -1846,7 +1844,6 @@ layer_map = {
     'Resize'                 : Resize,
     'UpSampling2D'           : Resize,
     'Transpose'              : Transpose,
-    'Permute'                : Transpose,
     'GarNet'                 : GarNet,
     'GarNetStack'            : GarNetStack,
     # TensorFlow-specific layers:

--- a/hls4ml/templates/vivado/nnet_utils/nnet_array.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_array.h
@@ -5,12 +5,26 @@
 
 namespace nnet {
 
-struct transpose3d_config {
+struct transpose_config {
     static const unsigned height = 10;
     static const unsigned width = 10;
     static const unsigned depth = 10;
     static constexpr unsigned perm[3] = {2, 0, 1};
 };
+
+template<class data_T, typename CONFIG_T>
+void transpose_2d(
+    data_T data[CONFIG_T::height * CONFIG_T::width],
+    data_T data_t[CONFIG_T::height * CONFIG_T::width]
+) {
+    #pragma HLS PIPELINE
+
+    for (int i = 0; i < CONFIG_T::height; i++) {
+        for (int j = 0; j < CONFIG_T::width; j++) {
+            data_t[j * CONFIG_T::height + i] = data[i * CONFIG_T::width + j];
+        }
+    }
+}
 
 template<class data_T, typename CONFIG_T>
 void transpose_3d(

--- a/hls4ml/templates/vivado_template.py
+++ b/hls4ml/templates/vivado_template.py
@@ -238,7 +238,7 @@ resize_config_template = """struct config{index} : nnet::resize_config {{
     static const unsigned new_width = {out_width};
 }};\n"""
 
-transpose_config_template = """struct config{index} : nnet::transpose3d_config {{
+transpose_config_template = """struct config{index} : nnet::transpose_config {{
     static const unsigned depth = {depth};
     static const unsigned height = {height};
     static const unsigned width = {width};


### PR DESCRIPTION
Here are the fixes for the Permute layer as proposed in fastmachinelearning/hls4ml#358. I added the 2D transpose as well and had to make extra fixes to support 3D. Apparently the shape that went into the config struct was wrong but this worked by chance in 2D.